### PR TITLE
Set background thread name property to "Logentries".

### DIFF
--- a/lelib/lecore.m
+++ b/lelib/lecore.m
@@ -56,7 +56,8 @@ void le_poke(void)
 {
     if (!backgroundThread) {
         backgroundThread = [LEBackgroundThread new];
-        
+        backgroundThread.name = @"Logentries";
+                
         NSCondition* initialized = [NSCondition new];
         backgroundThread.initialized = initialized;
         


### PR DESCRIPTION
It's helpful to see named thread in the Xcode debug area when possible, rather than "Thread #".  