### PR TITLE
Fix build errors when including project as a CocoaPod dependency

### DIFF
--- a/lelib/LogFiles.h
+++ b/lelib/LogFiles.h
@@ -7,7 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import <lelib/LogFile.h>
+#import "LogFile.h"
 
 
 @interface LogFiles : NSObject

--- a/lelib/lelib.h
+++ b/lelib/lelib.h
@@ -20,5 +20,5 @@
 #define LE_DEBUG(...)
 #endif
 
-#import <lelib/LELog.h>
-#import <lelib/lecore.h>
+#import "LELog.h"
+#import "lecore.h"


### PR DESCRIPTION
Fix build errors when including project as a CocoaPod dependency (`pod 'le', :git => "https://github.com/logentries/le_ios.git"`).