### PR TITLE
For swift compatibility moved LE_DEBUG_LOGS to a LELog instance property

### DIFF
--- a/demo/ViewController.m
+++ b/demo/ViewController.m
@@ -45,6 +45,7 @@
 {
     [super viewDidLoad];
     LELog* log = [LELog sharedInstance];
+    log.debugLogs = YES;
     log.token = @"f66815d1-702c-414b-8dcc-bb73de372584";
     log.logApplicationLifecycleNotifications = YES;
     

--- a/lelib/LELog.h
+++ b/lelib/LELog.h
@@ -23,6 +23,11 @@
 + (LELog*)sharedInstance;
 
 /*
+ Display all messages on TTY for debug purposes
+ */
+@property (nonatomic) BOOL debugLogs;
+
+/*
  Appends space separated token to each log message.
  */
 @property (atomic, copy) NSString* token;

--- a/lelib/LELog.m
+++ b/lelib/LELog.m
@@ -76,6 +76,11 @@ extern char* le_token;
     le_set_token([token cStringUsingEncoding:NSUTF8StringEncoding]);
 }
 
+- (void)setDebugLogs:(BOOL)debugLogs
+{
+    le_set_debug_logs(debugLogs);
+}
+
 - (NSString*)token
 {
     __block NSString* r = nil;

--- a/lelib/lecore.h
+++ b/lelib/lecore.h
@@ -17,6 +17,8 @@
 #define MAXIMUM_FILE_COUNT              3
 #define MAXIMUM_LOGFILE_SIZE            (1024 * 1024)
 
+extern void LE_DEBUG(NSString *format, ...);
+
 /* Pure C API */
 
 int le_init(void);
@@ -24,5 +26,6 @@ void le_poke(void);
 void le_log(const char* message);
 void le_write_string(NSString* string);
 void le_set_token(const char* token);
+void le_set_debug_logs(bool verbose);
 
 #endif

--- a/lelib/lecore.m
+++ b/lelib/lecore.m
@@ -17,6 +17,7 @@ LEBackgroundThread* backgroundThread;
 
 dispatch_queue_t le_write_queue;
 char* le_token;
+bool le_debug_logs = false;
 
 static int logfile_descriptor;
 static off_t logfile_size;
@@ -25,6 +26,17 @@ static int file_order_number;
 static char buffer[MAXIMUM_LOGENTRY_SIZE];
 
 static void (*saved_le_exception_handler)(NSException *exception);
+
+void LE_DEBUG(NSString *format, ...) {
+#if DEBUG
+    if (le_debug_logs) {
+        va_list args;
+        va_start(args, format);
+        NSLogv(format, args);
+        va_end(args);
+    }
+#endif
+}
 
 /*
  Sets logfile_descriptor to -1 when fails, this means that all subsequent write attempts will fail
@@ -235,4 +247,8 @@ void le_set_token(const char* token)
     dispatch_sync(le_write_queue, ^{
         le_token = local_buffer;
     });
+}
+
+void le_set_debug_logs(bool debug) {
+    le_debug_logs = debug;
 }

--- a/lelib/lelib.h
+++ b/lelib/lelib.h
@@ -6,19 +6,5 @@
 //  Copyright (c) 2013,2014 Logentries. All rights reserved.
 //
 
-#ifndef LE_DEBUG_LOGS
-    #ifdef DEBUG
-        #define LE_DEBUG_LOGS 1
-    #else
-        #define LE_DEBUG_LOGS 0
-    #endif
-#endif
-
-#if LE_DEBUG_LOGS
-#define LE_DEBUG(...)         NSLog(__VA_ARGS__)
-#else
-#define LE_DEBUG(...)
-#endif
-
 #import "LELog.h"
 #import "lecore.h"


### PR DESCRIPTION
On Swift it is not possible to use the `#define` macro, instead a [global constant](https://developer.apple.com/library/ios/documentation/Swift/Conceptual/BuildingCocoaApps/InteractingWithCAPIs.html) is used, because of this tiny but important difference it is not possible to "override" the `LE_DEBUG_LOGS` to disable debugging.

I purpose a simple change: move this option to a property on `LELog` instance.