### PR TITLE
Add LELog.handleCrashes()

### DIFF
--- a/lelib/LELog.h
+++ b/lelib/LELog.h
@@ -23,6 +23,8 @@
 + (LELog*)sharedInstance;
 
 + (LELog*)sessionWithToken:(NSString*)token;
+
++ (void)handleCrashes;
 /*
  Display all messages on TTY for debug purposes
  */

--- a/lelib/LELog.m
+++ b/lelib/LELog.m
@@ -80,6 +80,11 @@ extern char* le_token;
     [leLog setToken:token];
     return leLog;
 }
+
++ (void)handleCrashes {
+    le_handle_crashes();
+}
+
 - (void)setToken:(NSString *)token
 {
     le_set_token([token cStringUsingEncoding:NSUTF8StringEncoding]);

--- a/lelib/LELog.m
+++ b/lelib/LELog.m
@@ -30,6 +30,7 @@ extern char* le_token;
     [center addObserver:self selector:@selector(notificationReceived:) name:UIApplicationWillEnterForegroundNotification object:nil];
 
     le_poke();
+    le_handle_crashes();
 
     return self;
 }


### PR DESCRIPTION
# Why

We noticed that Logentries has an interface to log crashes, but it currently requires a function call in `main` which Swift projects don't have.

Instead, I thought we could try exposing that function call to the `LELog` class directly in the Pod, instead of creating our own wrapping class.